### PR TITLE
Moving copying libs_source/bootstrap/boostrap-<arch>.zip files from configure to prebuil

### DIFF
--- a/termux/termux-app/build.gradle.kts
+++ b/termux/termux-app/build.gradle.kts
@@ -8,9 +8,10 @@ plugins {
     id("kotlin-android")
 }
 
-apply {
-    plugin(TerminalBootstrapPackagesPlugin::class.java)
-}
+// -- runs on configure phase --
+//apply {
+//    plugin(TerminalBootstrapPackagesPlugin::class.java)
+//}
 
 val packageVariant = System.getenv("TERMUX_PACKAGE_VARIANT") ?: "apt-android-7" // Default: "apt-android-7"
 
@@ -75,4 +76,14 @@ tasks.register("versionName") {
     doLast {
         print(project.rootProject.version)
     }
+}
+
+tasks.register("applyTerminalBootstrapPackagesPlugin") {
+    doFirst {
+        project.pluginManager.apply(TerminalBootstrapPackagesPlugin::class.java)
+    }
+}
+
+tasks.named("preBuild").configure {
+    dependsOn("applyTerminalBootstrapPackagesPlugin")
 }


### PR DESCRIPTION
Fix for error that arises in  Task :termux:termux-app:buildNdkBuildDebug[<arch>] make due to absence of zip files when doing a Rebuild Project or if a full build from terminal/commandline i.e. gradlew clean assembleDebug